### PR TITLE
Add PW2IV sample and TCP pinning for extra security

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,10 @@ set_target_properties(event_system_example_local PROPERTIES ${DEFAULT_PROJECT_OP
 target_compile_options(event_system_example_local PRIVATE ${DEFAULT_COMPILE_OPTIONS})
 target_link_libraries(event_system_example_local rasta_udp)
 
+add_executable(pw2iv_sample
+        examples_localhost/c/pw2iv.c)
+target_compile_options(pw2iv_sample PRIVATE ${DEFAULT_COMPILE_OPTIONS})
+
 if(ENABLE_RASTA_TLS)
         add_executable(dtls_example_local
                 examples_localhost/c/dtls.c examples_localhost/c/wolfssl_certificate_helper.c examples_localhost/c/wolfssl_certificate_helper.h)

--- a/examples/config/rasta_client1_local_dtls.cfg
+++ b/examples/config/rasta_client1_local_dtls.cfg
@@ -114,3 +114,6 @@ RASTA_CA_PATH = "root-ca.pem"
 
 ; name of the TLS host to validate certificate common name against
 RASTA_TLS_HOSTNAME = "localhost"
+
+; path to peer certificate for certificate pinning - must be in .pem format
+RASTA_TLS_PEER_CERT_PATH = "server.pem"

--- a/examples/config/rasta_client1_local_kex.cfg
+++ b/examples/config/rasta_client1_local_kex.cfg
@@ -15,7 +15,7 @@ RASTA_T_H = 2000
 ;
 ; Note:
 ;   This property replaces the RASTA_MD4_TYPE property, although it can still be used for compatibility purposes
-RASTA_SR_CHECKSUM_LEN = NONE
+RASTA_SR_CHECKSUM_LEN = FULL
 
 ; Algorithms that is used for calculating the checksum in the SR layer
 ; Possible values:

--- a/examples/config/rasta_client1_local_tls.cfg
+++ b/examples/config/rasta_client1_local_tls.cfg
@@ -114,3 +114,6 @@ RASTA_CA_PATH = "root-ca.pem"
 
 ; name of the TLS host to validate certificate common name against
 RASTA_TLS_HOSTNAME = "localhost"
+
+; path to peer certificate for certificate pinning - must be in .pem format
+RASTA_TLS_PEER_CERT_PATH = "server.pem"

--- a/examples/config/rasta_client2_local_kex.cfg
+++ b/examples/config/rasta_client2_local_kex.cfg
@@ -15,7 +15,7 @@ RASTA_T_H = 2000
 ;
 ; Note:
 ;   This property replaces the RASTA_MD4_TYPE property, although it can still be used for compatibility purposes
-RASTA_SR_CHECKSUM_LEN = NONE
+RASTA_SR_CHECKSUM_LEN = FULL
 
 ; Algorithms that is used for calculating the checksum in the SR layer
 ; Possible values:

--- a/examples/config/rasta_server_local_dtls.cfg
+++ b/examples/config/rasta_server_local_dtls.cfg
@@ -115,3 +115,5 @@ RASTA_KEY_PATH = "server.key"
 
 ; name of the TLS host to validate certificate common name against
 RASTA_TLS_HOSTNAME = "localhost"
+
+; RASTA_TLS_PEER_CERT_PATH not set - no certificate pinning (no peer certificate...)

--- a/examples/config/rasta_server_local_kex.cfg
+++ b/examples/config/rasta_server_local_kex.cfg
@@ -15,7 +15,7 @@ RASTA_T_H = 2000
 ;
 ; Note:
 ;   This property replaces the RASTA_MD4_TYPE property, although it can still be used for compatibility purposes
-RASTA_SR_CHECKSUM_LEN = NONE
+RASTA_SR_CHECKSUM_LEN = FULL
 
 ; Algorithms that is used for calculating the checksum in the SR layer
 ; Possible values:

--- a/examples/config/rasta_server_local_tls.cfg
+++ b/examples/config/rasta_server_local_tls.cfg
@@ -115,3 +115,5 @@ RASTA_KEY_PATH = "server.key"
 
 ; name of the TLS host to validate certificate common name against
 RASTA_TLS_HOSTNAME = "localhost"
+
+; RASTA_TLS_PEER_CERT_PATH not set - no certificate pinning (no peer certificate...)

--- a/examples/examples_localhost/c/pw2iv.c
+++ b/examples/examples_localhost/c/pw2iv.c
@@ -1,0 +1,67 @@
+//
+// Created by erica on 02.08.22.
+//
+
+#include <inttypes.h>
+#include <endian.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static void usage(const char *name) {
+    fprintf(stderr, "Usage: %s <password>\n",name);
+    exit(1);
+}
+
+int main(int argc, char* argv[]){
+    size_t pw_len, pw_written;
+    const char *pw;
+    char *last_word;
+
+    const uint32_t MD4_STD_A= 0x67452301,
+    MD4_STD_B=0xefcdab89,
+    MD4_STD_C=0x98badcfe,
+    MD4_STD_D=0x10325476;
+
+    const size_t MD4_IV_WORDS = 4;
+    uint32_t output[MD4_IV_WORDS];
+
+    if(argc == 1){
+        usage(argv[0]);
+    }
+
+    pw = argv[1];
+
+    pw_len = strlen(pw);
+
+    if(pw_len > sizeof(output)){
+        fprintf(stderr,"Error: maximum password length is %lu bytes\n",sizeof(output));
+        return 1;
+    }
+
+    output[0] = htole32(MD4_STD_A);
+    output[1] = htole32(MD4_STD_B);
+    output[2] = htole32(MD4_STD_C);
+    output[3] = htole32(MD4_STD_D);
+
+    for(pw_written = 0; pw_written < pw_len - (pw_len % 4); pw_written += 4){
+        output[pw_written / 4] = htole32(*(uint32_t *)&pw[pw_written]);
+    }
+
+    last_word = (char *) &output[pw_len/4];
+    for(size_t i = 0; i < pw_len - pw_written; i++){
+         last_word[pw_len - pw_written - i - 1] = pw[pw_len - i - 1];
+    }
+    printf("; std: 0x%"PRIx32"\n",MD4_STD_A);
+    printf("RASTA_MD4_A = #%"PRIx32"\n",output[0]);
+    printf("; std: 0x%"PRIx32"\n",MD4_STD_B);
+    printf("RASTA_MD4_A = #%"PRIx32"\n",output[1]);
+    printf("; std: 0x%"PRIx32"\n",MD4_STD_C);
+    printf("RASTA_MD4_A = #%"PRIx32"\n",output[2]);
+    printf("; std: 0x%"PRIx32"\n",MD4_STD_D);
+    printf("RASTA_MD4_A = #%"PRIx32"\n",output[3]);
+
+
+    return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,13 @@
 if(ENABLE_RASTA_TLS)
     find_package(WolfSSL REQUIRED)
+    include(CheckSymbolExists)
+    check_symbol_exists(wolfSSL_set_tls13_secret_cb "wolfssl/ssl.h" WOLFSSL_SET_TLS13_SECRET_CB_EXISTS)
+    if(WOLFSSL_SET_TLS13_SECRET_CB_EXISTS)
+        add_compile_definitions("-DWOLFSSL_SET_TLS13_SECRET_CB_EXISTS")
+        message("Found method wolfSSL_set_tls 13_secret_cb - can provide TLS keys for debugging!")
+    else()
+        message("Could not find method wolfSSL_set_tls 13_secret_cb - cannot provide TLS keys for debugging!")
+    endif(WOLFSSL_SET_TLS13_SECRET_CB_EXISTS)
 endif(ENABLE_RASTA_TLS)
 
 if(ENABLE_RASTA_OPAQUE)

--- a/src/rasta/c/config.c
+++ b/src/rasta/c/config.c
@@ -802,6 +802,10 @@ void config_setstd(struct RastaConfig * cfg) {
         cfg->values.tls.tls_hostname[MAX_DOMAIN_LENGTH-1] = 0;
         memcpy(cfg->values.tls.tls_hostname,entr.value.string.c, MAX_DOMAIN_LENGTH);
     }
+    entr = config_get(cfg, "RASTA_TLS_PEER_CERT_PATH");
+    if(entr.type == DICTIONARY_STRING){
+        memcpy(cfg->values.tls.peer_tls_cert_path,entr.value.string.c,PATH_MAX);
+    }
 #endif
 
     cfg->values.kex.mode = KEY_EXCHANGE_MODE_NONE;

--- a/src/rasta/c/rasta_red_multiplexer.c
+++ b/src/rasta/c/rasta_red_multiplexer.c
@@ -359,6 +359,8 @@ int channel_accept_event(void *carry_data)
     struct rasta_connected_transport_channel_state connection;
     struct receive_event_data *data = carry_data;
 
+    connection.tls_config = &data->h->config.values.tls;
+
     logger_log(&data->h->mux.logger, LOG_LEVEL_DEBUG, "RaSTA RedMux accept", "Socket ready to accept");
     tcp_accept_tls(&data->h->mux.transport_states[data->channel_index], &connection);
 

--- a/src/rasta/c/udp.c
+++ b/src/rasta/c/udp.c
@@ -72,6 +72,9 @@ static void wolfssl_accept(struct RastaState *transport_state)
         fprintf(stderr, "WolfSSL could not accept connection: %s\n", wolfSSL_ERR_reason_error_string(e));
         exit(1);
     }
+
+    tls_pin_certificate(transport_state->ssl,transport_state->tls_config->peer_tls_cert_path);
+
     set_dtls_async(transport_state);
 }
 #endif

--- a/src/rasta/headers/config.h
+++ b/src/rasta/headers/config.h
@@ -105,6 +105,10 @@ struct RastaConfigTLS {
      * Domain / common name to validate TLS certificates against (as client)
      */
     char tls_hostname[MAX_DOMAIN_LENGTH];
+    /**
+     * path to peer certificate for certificate pinning. Optional.
+     */
+    char peer_tls_cert_path[PATH_MAX];
 };
 
 

--- a/src/rasta/headers/ssl_utils.h
+++ b/src/rasta/headers/ssl_utils.h
@@ -1,4 +1,4 @@
-
+#pragma once
 #ifndef TYPES_H
 #define TYPES_H
 #include "types.h"
@@ -36,3 +36,5 @@ void wolfssl_send_dtls(struct rasta_transport_state *transport_state, unsigned c
 ssize_t wolfssl_receive_tls(WOLFSSL *ssl, unsigned char *received_message, size_t max_buffer_len);
 
 void wolfssl_cleanup(struct rasta_transport_state *transport_state);
+
+void tls_pin_certificate(WOLFSSL *ssl, const char *peer_tls_cert_path);


### PR DESCRIPTION
Adds an example that allows mapping a passphrase to an MD4 IV as described in Annex A of the standard.
The output format is suitable for direct use in the configuration files.